### PR TITLE
Rhmap 14456 fhcap helpers

### DIFF
--- a/src/org/feedhenry/Utils.groovy
+++ b/src/org/feedhenry/Utils.groovy
@@ -17,6 +17,14 @@ def mapToList(depmap) {
     dlist
 }
 
+def mapToOptionsString(map) {
+    def optionsArray = []
+    for (def o in mapToList(map)) {
+        optionsArray << "${o[0]}:${o[1]}"
+    }
+    optionsArray.join(" ")
+}
+
 def getArtifactsDir(name) {
     return "${name}-artifacts"
 }

--- a/vars/fhcapNode.groovy
+++ b/vars/fhcapNode.groovy
@@ -1,0 +1,41 @@
+#!/usr/bin/groovy
+
+def call(Map parameters = [:], body) {
+
+    node('ruby-fhcap') {
+
+        env.RUBYOPT="-W0"
+
+        def installLatest = parameters.get('installLatest', false)
+        def credentialsId = parameters.get('credentialsId', 'jenkinsgithub')
+        def configFile = parameters.get('configFile', "${WORKSPACE}/fhcap.json")
+        def gitRepo = parameters.get('gitRepo', null)
+        def gitRef = parameters.get('gitRef', 'master')
+
+        step([$class: 'WsCleanup'])
+
+        if(gitRepo) {
+            dir('fhcap-cli') {
+                checkoutGitRepo {
+                    repoUrl = gitRepo
+                    branch = gitRef
+                }
+                sh "rake install"
+            }
+        } else {
+            if(installLatest) {
+                sh "gem install fhcap-cli --no-ri --no-rdoc"
+            }
+        }
+        sh "fhcap --version"
+
+        env.PATH = "${PATH}:/home/jenkins/bin"
+        env.FHCAP_CFG_FILE = configFile
+
+        sshagent([credentialsId]) {
+            sh "fhcap setup --repos-dir ${WORKSPACE} --fh-src-dir ${WORKSPACE}"
+        }
+
+        body()
+    }
+}

--- a/vars/fhcapProviderAdd.groovy
+++ b/vars/fhcapProviderAdd.groovy
@@ -1,0 +1,23 @@
+#!/usr/bin/groovy
+import org.feedhenry.Utils
+
+def call(body) {
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def utils = new Utils()
+
+    def name = config.name
+    def type = config.type
+    def credentials = config.credentials ?: [:]
+    def providerConfig = config.providerConfig ?: [:]
+
+    def credentialsStr = utils.mapToOptionsString(credentials)
+    def providerConfigStr = utils.mapToOptionsString(providerConfig)
+
+    def cmd = "fhcap provider add --name ${name} --type ${type} --credentials ${credentialsStr}"
+    cmd += providerConfigStr.trim() ? " --provider-config ${providerConfigStr.trim()}" : ''
+    sh cmd
+}

--- a/vars/fhcapRepoAdd.groovy
+++ b/vars/fhcapRepoAdd.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/groovy
+
+def call(body) {
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def name = config.name
+    def url = config.url
+    def clustersDir = config.clustersDir ?: 'clusters'
+    def verbose = config.verbose ?: false
+    def credentialsId = config.credentialsid ?: 'jenkinsgithub'
+
+    sshagent([credentialsId]) {
+        sh "fhcap repo add --name ${name} --url ${url} --clusters-dir ${clustersDir} --verbose ${verbose}"
+    }
+}

--- a/vars/withFhcap.groovy
+++ b/vars/withFhcap.groovy
@@ -2,6 +2,8 @@
 
 def call(body) {
 
+    print "Deprecated, use fhcapNode instead!"
+
     node('ruby-fhcap') {
 
         step([$class: 'WsCleanup'])


### PR DESCRIPTION
* Add fhcapNode, willl replace withFhcap
```
fhcapNode{
  //Do stuff
}
```

* New helper methods that should be used inside the fhcapNode:
   * fhcapProviderAdd (Add a provider for use aws,openstack etc..):
```
fhcapNode{
    fhcapProviderAdd {
        name = 'myprovider'
        type = 'openstack'
        credentials = [<cluster credentials>]
        providerConfig = [<provider config>]
    }
}
```
   * fhcapRepoAdd (Add an fhcap data repo):
```

fhcapNode{
    fhcapRepoAdd {
        name = "myrepo"
        url = "git@github.com:myorg/myrepo.git"
    }
}
```