### PR TITLE
Add fhcapRepoAddBatch method

### DIFF
--- a/vars/fhcapRepoAddBatch.groovy
+++ b/vars/fhcapRepoAddBatch.groovy
@@ -1,0 +1,20 @@
+#!/usr/bin/groovy
+import org.feedhenry.Utils
+
+def call(body) {
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def utils = new Utils()
+
+    def repos = config.repos ?: [:]
+
+    for (def repo in utils.mapToList(repos)) {
+        fhcapRepoAdd {
+            name = repo[0]
+            url = repo[1]
+        }
+    }
+}


### PR DESCRIPTION
Adds the given repos in one command.

Usage:
```
fhcapRepoAddBatch {
    repos = [
            'repo1': "git@repo1.git",
            'repo2': "git@repo2.git"
    ]
}
```