### PR TITLE
Component build helper methods

### DIFF
--- a/vars/fhBuildNode.groovy
+++ b/vars/fhBuildNode.groovy
@@ -1,0 +1,21 @@
+#!/usr/bin/groovy
+
+def call(Map parameters = [:], body) {
+
+    def label = parameters.get('label', 'nodejs-ubuntu')
+
+    node(label) {
+        step([$class: 'WsCleanup'])
+
+        stage ('Checkout') {
+            checkout scm
+        }
+
+        //Use short git commit hash value for component build number
+        env.BUILD_NUMBER = sh(returnStdout: true, script: "git rev-parse --short HEAD").trim()
+
+        ansiColor('xterm') {
+            body()
+        }
+    }
+}

--- a/vars/gruntBuild.groovy
+++ b/vars/gruntBuild.groovy
@@ -1,0 +1,16 @@
+#!/usr/bin/groovy
+
+def call(body) {
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    def name = config.name
+    def cmd = config.cmd ?: 'fh:dist --only-bundle-deps'
+
+    sh "npm install grunt-cli -g"
+    sh "grunt ${cmd}"
+
+    archiveArtifacts "dist/${name}*.tar.gz"
+}

--- a/vars/npmInstall.groovy
+++ b/vars/npmInstall.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/groovy
+
+def call(body) {
+    def config = [:]
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = config
+    body()
+
+    sh '''
+        npm install --production
+        npm ls
+        npm install
+      '''
+}


### PR DESCRIPTION
* Add fhBuildNode to setup correct environment for building any RHMAP component:

```
fhBuildNode {
   //Build steps here
}
```
* Add npmInstall to install npm dependencies for production and development:

```
npmInstall {}
```
* Add gruntBuild to execute a grunt based build and archive the created artifact:

```
gruntBuild {
   name = 'fh-aaa'
}
```