### PR TITLE
Added ability to require set of labels for a node

### DIFF
--- a/vars/fhBuildNode.groovy
+++ b/vars/fhBuildNode.groovy
@@ -1,10 +1,16 @@
 #!/usr/bin/groovy
 
 def call(Map parameters = [:], body) {
+    // We plan to deprecate the 'label' entry in params and use 'labels', containing a list of required labels
+    // The logic is:
+    // if labels exist, use those
+    // if label exists, use that
+    // if nothing exitst use nodejs-ubuntu
+    // in the future, we will replace this with:
+    // def labels = parameters.get('labels',[])
+    def labels = parameters.get('labels',[parameters.get('label','nodejs-ubuntu')])
 
-    def label = parameters.get('label', 'nodejs-ubuntu')
-
-    node(label) {
+    node(withLabels(labels)) {
         step([$class: 'WsCleanup'])
 
         stage ('Checkout') {

--- a/vars/fhcapNode.groovy
+++ b/vars/fhcapNode.groovy
@@ -2,9 +2,12 @@
 
 def call(Map parameters = [:], body) {
 
-    def label = parameters.get('label', 'ruby-fhcap')
+    def labels = [parameters.get('label','ruby-fhcap')]
+    labels += parameters.get('labels',[]) 
+    def provider = parameters.get('provider')  ?: [:]
+    labels += provider.get('labels',[])
 
-    node(label) {
+    node(withLabels(labels)) {
 
         def installLatest = parameters.get('installLatest', false)
         def credentialsId = parameters.get('credentialsId', 'jenkinsgithub')

--- a/vars/withLabels.groovy
+++ b/vars/withLabels.groovy
@@ -1,0 +1,7 @@
+#!/usr/bin/groovy
+
+def call(labelSet) {
+    labels = ((labelSet as Set) - [null]).join('&&')
+    print "Requesting node with ${labels}"
+    labels
+}


### PR DESCRIPTION
Added new utility function, nodeWithLabels, that accepts anything of strings that can be coerced to Set, and then asks for a node containing all of those labels.

Changed both fhcapNode and fhBuildNode to accept labels as a parameter that would be passed in to nodeWithLabels.

fhcapNode
* will always require node with at least label 'fhcap'.
* will require all labels in parameters.provider.labels, if present
  * used i.e here: https://github.com/AdamSaleh/jenkins-bob-builder/blob/behind_vpn_slaves/scripts/add_providers_config.groovy#L7 
  * requires added propagation of the provider config to fhcapNode in JenkinsBobBuilder repo

fhBuildNode 
* will always require node with at least labels 'nodejs' and 'ubuntu'

This means that to accept these changes, jenkins to run this should already have labels set by https://github.com/feedhenry/wendy-jenkins-s2i-configuration/pull/29 