### PR TITLE
✨ Add withOpenshiftServices DSL step method

### DIFF
--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -1,0 +1,124 @@
+def call(services, body) {
+    List<String> names = getNames(services)
+    try {
+        createOpenshiftResources(services, names)
+        withEnv(env(services, names)) {
+            body()
+        }
+    } finally {
+        cleanup(names)
+    }
+}
+
+def cleanup(names) {
+    for (int i = 0; i < names.size(); i++) {
+        String resourceName = names[0]
+        openshiftScale deploymentConfig: resourceName,  replicaCount: 0
+        openshift.withCluster() {
+            openshift.selector('svc', [name: resourceName]).delete()
+            openshift.selector('dc', [name: resourceName]).delete()
+        }
+    }
+}
+
+def createOpenshiftResources(services, names) {
+    Map jobs = [:]
+    for (int i = 0; i < services.size(); i++) {
+        String service = services[i]
+        String name = names[i]
+        jobs[name] = {
+            openshiftCreateResource(getDeploymentConfigYaml(service, name))
+            openshiftCreateResource(getServiceYaml(service, name))
+            openshiftScale deploymentConfig: name,  replicaCount: 1, verifyReplicaCount: 1
+        }
+    }
+    parallel jobs
+}
+
+String sanitizeObjectName(s) {
+    s.replace('_', '-').toLowerCase()
+}
+
+Map<String, String> getNames(services) {
+    List<String> names = []
+    for (int i = 0; i < services.size(); i++) {
+        names += sanitizeObjectName("${env.BUILD_TAG}-${services[i]}")
+    }
+    return names
+}
+
+List<String> env(services, names) {
+    List<String> out = []
+    if (services.contains('mongodb')) {
+        out.add("MONGODB_HOST=${names[services.indexOf('mongodb')]}")
+    }
+    return out
+}
+
+String getDeploymentConfigYaml(service, name) {
+    switch (service) {
+        case 'mongodb':
+        return """
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: ${name}
+  labels:
+    name: ${name}
+spec:
+  replicas: 0
+  selector:
+    name: ${name}
+  strategy:
+    recreateParams:
+      timeoutSeconds: 600
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: ${name}
+    spec:
+      containers:
+      - image: docker.io/mongo:3
+        imagePullPolicy: IfNotPresent
+        name: mongodb
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /data/db
+          name: data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: data
+"""
+        default:
+        return ''
+    }
+}
+
+String getServiceYaml(service, name) {
+    switch (service) {
+        case 'mongodb':
+        return """
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${name}
+  labels:
+    name: ${name}
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    name: ${name}
+  type: ClusterIP
+"""
+        default:
+        return ''
+    }
+}


### PR DESCRIPTION
This step wraps around the 'body' that it's provided with, and
provides it with resources running in the OpenShift project.

It will first create the DeploymentConfig and Service objects for the
resources, and scale the deployments up to 1 replica, then it will
attempt to execute the body. This is all wrapped in a `try...finally`,
so even if something goes wrong, the resources will be cleaned
up afterwards.