### PR TITLE
🐛 Make service cleanup more reliable

### DIFF
--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -1,38 +1,36 @@
 def call(services, body) {
-    List<String> names = getNames(services)
-    try {
-        createOpenshiftResources(services, names)
-        withEnv(env(services, names)) {
-            body()
-        }
-    } finally {
-        cleanup(names)
-    }
-}
-
-def cleanup(names) {
-    for (int i = 0; i < names.size(); i++) {
-        String resourceName = names[0]
-        openshiftScale deploymentConfig: resourceName,  replicaCount: 0
-        openshift.withCluster() {
-            openshift.selector('svc', [name: resourceName]).delete()
-            openshift.selector('dc', [name: resourceName]).delete()
-        }
-    }
-}
-
-def createOpenshiftResources(services, names) {
-    Map jobs = [:]
-    for (int i = 0; i < services.size(); i++) {
-        String service = services[i]
-        String name = names[i]
-        jobs[name] = {
+    def buildingClosure = { prevFn, _service, _name ->
+        String name = _name
+        String service = _service
+        try {
             openshiftCreateResource(getDeploymentConfigYaml(service, name))
             openshiftCreateResource(getServiceYaml(service, name))
-            openshiftScale deploymentConfig: name,  replicaCount: 1, verifyReplicaCount: 1, waitTime: 600000
+            openshiftScale deploymentConfig: name,  replicaCount: 1, verifyReplicaCount: 1
+            prevFn()
+        } finally {
+            openshift.withCluster() {
+                try {
+                    openshiftScale deploymentConfig: name,  replicaCount: 0
+                } finally {
+                    try {
+                        openshift.selector('svc', [name: name]).delete()
+                    } finally {
+                        openshift.selector('dc', [name: name]).delete()
+                    }
+                }
+            }
         }
     }
-    parallel jobs
+
+    List<String> names = getNames(services)
+    def builtFunction = body;
+    for (int i = 0; i < names.size(); i++) {
+        builtFunction = buildingClosure.curry(builtFunction, services[i], names[i])
+    }
+
+    withEnv(env(services, names)) {
+        builtFunction()
+    }
 }
 
 String sanitizeObjectName(s) {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-15990

There's a bunch of stuff that previousl would happen in the 'cleanup'
function, and in some cases an exception could be thrown. To ensure
that all resources are scaled down and cleaned up, we basically need
to wrap each step there in a `try...finally`.

This solution is made more complex because we don't really know how
many services are needed, so before this change we'd loop over them
and clean them all up. If we want to chain a bunch of
`try...finally`'s, then we can build that chain in a series of nested
closures at runtime (call `buildingClosure` in a loop), and then
execute all together (`builtFunction()`).

That's what I've attempted to achieve in this solution, and I think I
have. Since we only support MongoDB currently, I haven't been able to
test with more than a single service request. Additionally, where we
were getting parallelization in the service creation/scaling, that's
now lost if we go with this approach. I'm sure there's another way
where we get the best of both worlds, but I haven't gotten there yet.