### PR TITLE
Rhmap 15936 add build info

### DIFF
--- a/src/org/feedhenry/Utils.groovy
+++ b/src/org/feedhenry/Utils.groovy
@@ -9,6 +9,10 @@ def getReleaseTag(version) {
     "rh-release-${version}-rc1"
 }
 
+def getBuildInfoFileName() {
+    'build-info.json'
+}
+
 def mapToList(depmap) {
     def dlist = []
     for (entry in depmap) {

--- a/vars/gruntBuild.groovy
+++ b/vars/gruntBuild.groovy
@@ -13,5 +13,8 @@ def call(body) {
         cmd = distCmd
     }
 
-    archiveArtifacts "dist/${name}*.tar.gz"
+    def pkgVersion = sh(returnStdout: true, script: "node -p -e \"require('./package.json').version\"").trim()
+    def buildInfoFileName = writeBuildInfo(name, "${pkgVersion}-${env.BUILD_NUMBER}")
+
+    archiveArtifacts "dist/${name}*.tar.gz, ${buildInfoFileName}"
 }

--- a/vars/npmInstall.groovy
+++ b/vars/npmInstall.groovy
@@ -10,5 +10,6 @@ def call(body) {
         npm install --production
         npm ls
         npm install
+        npm install grunt-cli -g
       '''
 }

--- a/vars/stashComponentArtifacts.groovy
+++ b/vars/stashComponentArtifacts.groovy
@@ -1,4 +1,5 @@
 #!/usr/bin/groovy
+
 import org.feedhenry.Utils
 
 def call(name, sha1, projectName) {
@@ -12,11 +13,14 @@ def call(name, sha1, projectName) {
                 parameters: "name=${name},sha1=${sha1}",
                 projectName: projectName,
                 selector: [
-                        $class: 'StatusBuildSelector', stable: false],
+                        $class: 'StatusBuildSelector', stable: true],
                 target: utils.getArtifactsDir(name)
         ])
         dir(utils.getArtifactsDir(name)) {
-            writeFile file: 'sha1.txt', text: sha1
+            def buildInfoFileName = utils.getBuildInfoFileName()
+            if (!fileExists(buildInfoFileName)) {
+                error "${buildInfoFileName} does not exist in the artifacts of ${name}"
+            }
         }
         stash includes: "${utils.getArtifactsDir(name)}/", name: name
     }

--- a/vars/unstashComponentArtifacts.groovy
+++ b/vars/unstashComponentArtifacts.groovy
@@ -1,14 +1,20 @@
 #!/usr/bin/groovy
+
+import groovy.json.JsonSlurperClassic
 import org.feedhenry.Utils
 
 def call(name, body) {
     def utils = new Utils()
     unstash name
     dir(utils.getArtifactsDir(name)) {
-        def version = readFile "VERSION.txt"
-        version = version.trim().split('-')[0]
-        def build = readFile "sha1.txt"
-        build = build.take(7)
+        def buildInfoFileName = utils.getBuildInfoFileName()
+        if (!fileExists(buildInfoFileName)) {
+            error "${buildInfoFileName} does not exist in the artifacts of ${name}"
+        }
+        def buildInfoRaw = readFile buildInfoFileName
+        buildInfo = new JsonSlurperClassic().parseText buildInfoRaw
+        def version = buildInfo[name]['version']
+        def build = buildInfo[name]['build']
         body(version, build)
     }
 }

--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -29,7 +29,7 @@ def createOpenshiftResources(services, names) {
         jobs[name] = {
             openshiftCreateResource(getDeploymentConfigYaml(service, name))
             openshiftCreateResource(getServiceYaml(service, name))
-            openshiftScale deploymentConfig: name,  replicaCount: 1, verifyReplicaCount: 1
+            openshiftScale deploymentConfig: name,  replicaCount: 1, verifyReplicaCount: 1, waitTime: 600000
         }
     }
     parallel jobs

--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -36,7 +36,7 @@ def createOpenshiftResources(services, names) {
 }
 
 String sanitizeObjectName(s) {
-    s.replace('_', '-').toLowerCase()
+    s.replace('_', '-').toLowerCase().reverse().take(63).reverse()
 }
 
 Map<String, String> getNames(services) {

--- a/vars/writeBuildInfo.groovy
+++ b/vars/writeBuildInfo.groovy
@@ -1,0 +1,29 @@
+#!/usr/bin/groovy
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurperClassic
+import org.feedhenry.Utils
+
+def call(name, versionTxt) {
+    def utils = new Utils()
+    def buildInfoFileName = utils.getBuildInfoFileName()
+    def buildInfo = [:]
+
+    if(fileExists(buildInfoFileName)) {
+        def buildInfoRaw = readFile buildInfoFileName
+        print buildInfoRaw
+        buildInfo = new JsonSlurperClassic().parseText buildInfoRaw
+        print buildInfo
+    }
+
+    buildInfo['jenkinsUrl'] = env.JENKINS_URL
+    buildInfo['buildUrl'] = env.BUILD_URL
+    buildInfo['sha1'] = sh(returnStdout: true, script: 'git log -n 1 --pretty=format:"%H"').trim()
+
+    buildInfo[name] = [:]
+    buildInfo[name]['version'] = versionTxt.split('-')[0]
+    buildInfo[name]['build'] = env.BUILD_NUMBER
+
+    writeFile file: buildInfoFileName, text: new JsonBuilder(buildInfo).toPrettyString()
+    return buildInfoFileName
+}


### PR DESCRIPTION
* Adds a writeBuildInfo helper that adds a json formatted metadata fil to a build that is then used during the stash/unstash of artifacts.
* Increase the timeout on the OpenShift scale command to 10 minutes.
* Ensure OpenShift service names are no longer than 63 chars.

Jira:

https://issues.jboss.org/browse/RHMAP-16052