### PR TITLE
Openshift service name length and custom job info 

### DIFF
--- a/vars/fhBuildNode.groovy
+++ b/vars/fhBuildNode.groovy
@@ -13,8 +13,17 @@ def call(Map parameters = [:], body) {
     node(withLabels(labels)) {
         step([$class: 'WsCleanup'])
 
+        if(params.name) {
+            currentBuild.displayName = "${currentBuild.displayName} ${params.name}"
+        }
+
         stage ('Checkout') {
             checkout scm
+        }
+
+        if(params.name) {
+            def gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+            currentBuild.description = gitCommit
         }
 
         //Use short git commit hash value for component build number

--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -36,7 +36,13 @@ def createOpenshiftResources(services, names) {
 }
 
 String sanitizeObjectName(s) {
-    s.replace('_', '-').toLowerCase().reverse().take(23).reverse()
+    s.replace('_', '-')
+            .toLowerCase()
+            .reverse()
+            .take(23)
+            .replaceAll("^-+", "")
+            .reverse()
+            .replaceAll("^-+", "")
 }
 
 Map<String, String> getNames(services) {

--- a/vars/withOpenshiftServices.groovy
+++ b/vars/withOpenshiftServices.groovy
@@ -36,7 +36,7 @@ def createOpenshiftResources(services, names) {
 }
 
 String sanitizeObjectName(s) {
-    s.replace('_', '-').toLowerCase().reverse().take(63).reverse()
+    s.replace('_', '-').toLowerCase().reverse().take(23).reverse()
 }
 
 Map<String, String> getNames(services) {


### PR DESCRIPTION
* Limit the OpenShift resource names to 23 chars. Older versions of Kubernetes enforce this (OpenShift < 3.4)
* Add extra info to the display name and description, but only if the name param exists. The name param is only passed in via custom Jenkins jobs and we don't need to display this information on the normal PR job view since its all separated by component and branch anyway.

![buildnameanddescription](https://user-images.githubusercontent.com/327352/26922357-d646a90a-4c36-11e7-9308-861efa56c1f8.png)
