### PR TITLE
Rhmap 14039 release branch

### DIFF
--- a/src/org/feedhenry/Utils.groovy
+++ b/src/org/feedhenry/Utils.groovy
@@ -5,11 +5,11 @@ import java.text.SimpleDateFormat
 
 static def getReleaseBranch(version) {
     def versionParts = version.tokenize(".")
-    return "RH_v${versionParts[0]}.${versionParts[1]}"
+    return "FH-v${versionParts[0]}.${versionParts[1]}"
 }
 
 static def getReleaseTag(version, candidate) {
-    "rh-release-${version}-${candidate}"
+    "release-${version}-${candidate}"
 }
 
 static def getBuildInfoFileName() {

--- a/src/org/feedhenry/Utils.groovy
+++ b/src/org/feedhenry/Utils.groovy
@@ -4,7 +4,8 @@ package org.feedhenry
 import java.text.SimpleDateFormat
 
 static def getReleaseBranch(version) {
-    "RH_v${version}"
+    def versionParts = version.tokenize(".")
+    return "RH_v${versionParts[0]}.${versionParts[1]}"
 }
 
 static def getReleaseTag(version) {

--- a/src/org/feedhenry/Utils.groovy
+++ b/src/org/feedhenry/Utils.groovy
@@ -8,8 +8,8 @@ static def getReleaseBranch(version) {
     return "RH_v${versionParts[0]}.${versionParts[1]}"
 }
 
-static def getReleaseTag(version) {
-    "rh-release-${version}-rc1"
+static def getReleaseTag(version, candidate) {
+    "rh-release-${version}-${candidate}"
 }
 
 static def getBuildInfoFileName() {

--- a/vars/buildComponent.groovy
+++ b/vars/buildComponent.groovy
@@ -15,5 +15,7 @@ def call(name, sha1, projectName, config) {
         jobParams << [$class: 'StringParameterValue', name: 'distCmd', value: distCmd]
     }
 
-    build job: projectName, parameters: jobParams
+    retry(2) {
+        build job: projectName, parameters: jobParams
+    }
 }


### PR DESCRIPTION
Release related changes:

* Use shared minor release branch e.g. FH-v9.9
* Add release candidate parameter to release tag helpers.
* Update release branch and tag pattern to match current process e.g. FH-vx.y, release-x.y.z-rc1