### PR TITLE
Remove --only-bundle-deps flag from node modules dist command.

### DIFF
--- a/vars/gruntBuild.groovy
+++ b/vars/gruntBuild.groovy
@@ -7,7 +7,7 @@ def call(body) {
     body()
 
     def name = config.name
-    def distCmd = config.distCmd ?: 'fh:dist --only-bundle-deps'
+    def distCmd = config.distCmd ?: 'fh:dist'
 
     gruntCmd {
         cmd = distCmd


### PR DESCRIPTION
*  We require the other artifact when deploying to non linux instances (OSX build farm)