### PR TITLE
Adding new getChefServerCredentialsId helper

### DIFF
--- a/vars/getChefServerCredentialsId.groovy
+++ b/vars/getChefServerCredentialsId.groovy
@@ -1,0 +1,8 @@
+#!/usr/bin/groovy
+
+def call(String name) {
+    def chefServerNameSplit = (name.split('-') as List<String>)
+    chefServerNameSplit.push("chef")
+    def String chefServerCredentialsId = chefServerNameSplit.unique().join('-')
+    return chefServerCredentialsId
+}


### PR DESCRIPTION
**Summary**
Adding new helper for determining Chef Server credentials ID.

**Related Jira**
https://issues.jboss.org/browse/RHMAP-16288

**Related PR**
https://github.com/fheng/jenkins-bob-builder/pull/330

**Examples**
_Scenario 1:_ Cluster using bob as chef server:
_Expected Result:_ chef server credentials ID will be bob-chef

_Scenario 2:_ Cluster using sam1-chef as chef server
_Expected Result:_ chef server credentials ID will be sam1-chef

**Validation**
https://jenkins-wendy.local.feedhenry.io/blue/organizations/jenkins/rhmap_cluster_deploy_generated/detail/rhmap_cluster_deploy_generated/246/pipeline/