### PR TITLE
Add optional parseVersionText option to writeBuildInfo

### DIFF
--- a/vars/writeBuildInfo.groovy
+++ b/vars/writeBuildInfo.groovy
@@ -4,12 +4,12 @@ import groovy.json.JsonBuilder
 import groovy.json.JsonSlurperClassic
 import org.feedhenry.Utils
 
-def call(name, versionTxt) {
+def call(String name, String versionText, boolean parseVersionText = true) {
     def utils = new Utils()
     def buildInfoFileName = utils.getBuildInfoFileName()
     def buildInfo = [:]
 
-    if(fileExists(buildInfoFileName)) {
+    if (fileExists(buildInfoFileName)) {
         def buildInfoRaw = readFile buildInfoFileName
         print buildInfoRaw
         buildInfo = new JsonSlurperClassic().parseText buildInfoRaw
@@ -21,7 +21,7 @@ def call(name, versionTxt) {
     buildInfo['sha1'] = sh(returnStdout: true, script: 'git log -n 1 --pretty=format:"%H"').trim()
 
     buildInfo[name] = [:]
-    buildInfo[name]['version'] = versionTxt.split('-')[0]
+    buildInfo[name]['version'] = parseVersionText ? versionText.split('-')[0] : versionText
     buildInfo[name]['build'] = env.BUILD_NUMBER
 
     writeFile file: buildInfoFileName, text: new JsonBuilder(buildInfo).toPrettyString()


### PR DESCRIPTION
* Add optional parseVersionText option to writeBuildInfo DSL method, defaults to true.
If true, the versionText string will be parsed to remove unwanted text.