### PR TITLE
📚 Link to jenkins docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # fh-pipeline-library
 FH Pipeline for Jenkins
+
+To learn how you to use this library, refer to the [Jenkins documentation page](https://jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries)


### PR DESCRIPTION
Added link to the Jenkins documentation page explaining how to use Global shared libraries.