### PR TITLE
Added utility function to send IRC message

### DIFF
--- a/vars/sendIRC.groovy
+++ b/vars/sendIRC.groovy
@@ -1,0 +1,13 @@
+import hudson.plugins.ircbot.v2.IRCConnectionProvider;
+import hudson.plugins.im.*
+
+def call(message, room = "#aerogear") {
+    try {
+    def conP = IRCConnectionProvider.getInstance()
+    def con = conP.currentConnection()
+    con.send(room, message)
+    } catch (err) {
+        print "There was a problem when trying to send message to ${room} through IRC Plugin"
+        print err
+    } 
+}


### PR DESCRIPTION
When working with IRC Plugin, there is no way to send irc messages from pipelines out of the box.
Adding a util function that uses the underlying library and configuration to send message.