### PR TITLE
Made the error in label reading fall-through

### DIFF
--- a/vars/getPullRequestLabels.groovy
+++ b/vars/getPullRequestLabels.groovy
@@ -49,5 +49,10 @@ def call(body) {
     def pr = config.pr ?: prnfo["id"]
     def credentials = config.credentials ?: "githubjenkins"
    
-    return getLabels(Integer.parseInt(pr), repo, org, credentials) 
+    try {
+      return getLabels(Integer.parseInt(pr), repo, org, credentials) 
+    } catch (err) {
+      print "Problem while getting labels from ${org} ${repo} ${pr}, returning empty list"
+      return []
+    }
 }


### PR DESCRIPTION
There is a problem when trying to get labels while not in a PR branch. I added try/catch around it as a quick solution.